### PR TITLE
correct capitalization in filename

### DIFF
--- a/configure/strava/index.md
+++ b/configure/strava/index.md
@@ -4,7 +4,7 @@ title: "Configure Strava"
 
 angular_includes:
   - "{{ site.baseurl }}/app/tractdbConfig.js"
-  - "{{ site.baseurl }}/app/loginForstravaApp.js"
+  - "{{ site.baseurl }}/app/loginForStravaApp.js"
 ---
 
 <header>


### PR DESCRIPTION
Interestingly it worked on my file system. I thought osx was picky about capitalization.